### PR TITLE
chore: add clean-code and unclean-code folders with modules-explained…

### DIFF
--- a/modules_explained/system/clean-code/system_c.py
+++ b/modules_explained/system/clean-code/system_c.py
@@ -1,0 +1,10 @@
+import sys
+print(sys.version);
+print("\n");
+print(sys.executable);
+print("\n");
+print(sys.path);
+print("\n");
+print(sys.platform);
+print("\n");
+print("\n");

--- a/modules_explained/system/unclean-code/system_u.py
+++ b/modules_explained/system/unclean-code/system_u.py
@@ -1,0 +1,38 @@
+# sys là một module tích hợp (built-in module) quan trọng trong Python.
+# sys cung cấp các BIẾN và HÀM để tương tác với trình thông dịch Python và môi trường hệ thống.
+
+#   Import sys
+#   Module sys cung cấp các BIẾN và các HÀM để tương tác với tình thông dịch python và hệ thống.
+import sys
+
+#   print(sys.version) là in ra thông tin phiên bản của trình thông dịch Python (thuộc tính version của module sys )
+print(sys.version);
+print("\n");
+
+# print(sys.excutable) để lấy và in ra đường dẫn đến thư mục chứa file python (thuộc tính excutable của module sys)
+print(sys.executable);
+print("\n");
+
+# print (sys.path) để lấy và in đường dẫn đến thư mục chứa file python (thuộc tính path của module sys)
+print(sys.path);
+print("\n");
+
+# print(sys.platform) để lấy thông tin về hệ thống và in ra thông tin hệ thống (thuộc tính platform của module sys)
+print(sys.platform);
+print("\n");
+
+# print("\n") để in ra khoảng trống xuống dòng
+# Xuống dòng
+print("\n");
+
+# Chạy file python trong terminal bằng cách sử dụng python + tên file
+# Có thể code python trong terminal bằng cách sử dụng python -m + tên file
+
+# python -m system
+# python -m system là chạy file system.py trong terminal
+
+# Sử dụng exit() để thoát khỏi terminal
+
+# Sử dụng , gõ python vào terminal và nhấn enter để vào python shell
+# Python Shell là môi trường giao diện dòng lệnh (command line interface) cho phép người dùng nhập và thực thi mã Python trực tiếp
+

--- a/notes/module/module.md
+++ b/notes/module/module.md
@@ -1,0 +1,126 @@
+# Module sys trong Python
+
+## 1. Giới thiệu
+`sys` là một module tích hợp (built-in module) quan trọng trong Python, được sử dụng để tương tác với trình thông dịch Python và môi trường hệ thống.
+
+## 2. Cách Import
+```python
+import sys
+```
+
+## 3. Các chức năng chính
+
+### 3.1. Thông tin hệ thống
+| Thuộc tính/Phương thức | Mô tả |
+|------------------------|--------|
+| `sys.version` | Thông tin về phiên bản Python đang sử dụng |
+| `sys.platform` | Thông tin về nền tảng hệ điều hành |
+| `sys.executable` | Đường dẫn đến trình thông dịch Python |
+
+### 3.2. Quản lý đường dẫn
+| Thuộc tính/Phương thức | Mô tả |
+|------------------------|--------|
+| `sys.path` | Danh sách các đường dẫn tìm kiếm module |
+| `sys.modules` | Dictionary chứa các module đã được import |
+
+### 3.3. Xử lý đầu vào/đầu ra tiêu chuẩn
+| Thuộc tính/Phương thức | Mô tả |
+|------------------------|--------|
+| `sys.stdin` | Đầu vào chuẩn |
+| `sys.stdout` | Đầu ra chuẩn |
+| `sys.stderr` | Đầu ra lỗi chuẩn |
+
+### 3.4. Quản lý bộ nhớ và tài nguyên
+| Thuộc tính/Phương thức | Mô tả |
+|------------------------|--------|
+| `sys.getsizeof()` | Lấy kích thước của đối tượng trong bộ nhớ |
+| `sys.getrefcount()` | Đếm số tham chiếu đến một đối tượng |
+
+## 4. Ví dụ sử dụng
+
+### 4.1. Kiểm tra phiên bản Python
+```python
+import sys
+print(sys.version)
+```
+
+### 4.2. Kiểm tra hệ điều hành
+```python
+import sys
+print(sys.platform)
+```
+
+### 4.3. Xem đường dẫn tìm kiếm module
+```python
+import sys
+print(sys.path)
+```
+
+### 4.4. Lấy đường dẫn Python interpreter
+```python
+import sys
+print(sys.executable)
+```
+
+## 5. Các lệnh terminal liên quan
+
+### 5.1. Chạy file Python
+```bash
+python tên_file.py
+```
+
+### 5.2. Chạy module
+```bash
+python -m tên_module
+```
+
+### 5.3. Vào Python shell
+```bash
+python
+```
+
+## 6. Lưu ý quan trọng
+- Python Shell là môi trường giao diện dòng lệnh cho phép thực thi mã Python trực tiếp
+- Sử dụng `exit()` để thoát khỏi Python shell
+- Module sys rất hữu ích cho việc:
+  - Kiểm tra và quản lý môi trường Python
+  - Xử lý tham số dòng lệnh
+  - Tương tác với hệ điều hành
+  - Quản lý bộ nhớ và tài nguyên hệ thống
+
+## 7. Code mẫu hoàn chỉnh
+```python
+# sys là module tích hợp trong Python, cung cấp các biến và hàm để:
+# - Tương tác với trình thông dịch Python
+# - Truy cập thông tin hệ thống
+# - Quản lý đường dẫn và module
+# - Xử lý đầu vào/đầu ra tiêu chuẩn
+import sys
+
+# Lấy thông tin về phiên bản Python
+print("Python version:")
+print(sys.version)
+print("\n")
+
+# Lấy đường dẫn đến thư mục chứa file python
+print("Python executable path:")
+print(sys.executable)
+print("\n")
+
+# Lấy danh sách đường dẫn tìm kiếm module
+print("Python module search paths:")
+print(sys.path)
+print("\n")
+
+# Lấy thông tin về hệ điều hành
+print("Operating system platform:")
+print(sys.platform)
+print("\n")
+```
+
+## 8. Tài liệu tham khảo
+- [Python sys module documentation](https://docs.python.org/3/library/sys.html)
+- [Python.org](https://www.python.org/)
+
+---
+*Ghi chú: Tài liệu này được tạo để giúp hiểu rõ hơn về module sys trong Python. Hãy tham khảo tài liệu chính thức của Python để biết thêm chi tiết.*


### PR DESCRIPTION
### Changes
- Added two folders: `clean-code` and `unclean-code`, each containing examples for the `system` module.
- The `clean-code` version includes clearly explained and readable code, with little or no comments,
while the `unclean-code` version includes annotated code, explained in extremely detailed and clear terms, both in my understanding and in ChatGPT's professional interpretation.

### Thay đổi
- Thêm hai thư mục: `clean-code` và `unclean-code`, mỗi thư mục chứa các ví dụ cho mô-đun `system`.
- Phiên bản `clean-code` bao gồm mã được giải thích rõ ràng và dễ đọc, có thể không có chú thích hoặc ít,
còn phiên bản `unclean-code` bao gồm mã được chú thích, giải thích 1 cách cực kỳ chi tiết, rõ ràng bởi ý hiểu của tôi cũng như sự gải thích laioj chuyển nghiệp của ChatGPT.